### PR TITLE
Logging tweaks, plus don't exit if rsync doesn't return successfully,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,23 +30,15 @@ To run a backup (using the `semantic` cluster as an example):
 
         ssh core@semantic-tunnel-up.ft.com
 
-1. Stop the deployer, red ingester, and red annotator:
+1. Stop the deployer, red ingester, and red annotators, then run the backup and watch the logs (it should take about half an hour):
 
-        fleetctl stop deployer.service
-        fleetctl stop content-ingester-neo4j-red@1.service v1-content-annotator-red@1.service v2-content-annotator-red@1.service
+        fleetctl stop deployer.service content-ingester-neo4j-red@1.service v1-content-annotator-red@1.service v2-content-annotator-red@1.service \
+            && fleetctl start neo4j-backup.service \
+            && fleetctl journal -f neo4j-backup.service
 
-1. Run the backup:
+1. Start the services that you stopped earlier:
 
-        fleetctl start neo4j-backup.service
-
-1. Wait for it to finish (it should take about half an hour):
-
-        fleetctl journal -f neo4j-backup.service
-
-1. Start the red annotators, the red ingester and the deployer:
-
-        fleetctl start deployer.service
-        fleetctl start content-ingester-neo4j-red@1.service v1-content-annotator-red@1.service v2-content-annotator-red@1.service
+        fleetctl start deployer.service content-ingester-neo4j-red@1.service v1-content-annotator-red@1.service v2-content-annotator-red@1.service
 
 
 How to run a restore

--- a/main.go
+++ b/main.go
@@ -158,11 +158,12 @@ func runInner(
 				"dataFolder": dataFolder,
 				"targetFolder": targetFolder,
 				"err": err,
-			}).Warn("Encountered another error synchronising neo4j files while database is running (i.e. hot); backup process failed.")
-			return err
+			}).Warn("Encountered another error synchronising neo4j files while database is running " +
+				"(i.e. hot); backup process failed to complete successfully. " +
+				"The cold backup phase will consequently take longer than usual.")
 		}
 	}
-	log.Info("hot rsync completed, shutting down neo...")
+	log.Info("Hot rsync completed, shutting down neo...")
 	err = shutDownNeo(fleetClient)
 	if err != nil {
 		log.WithFields(log.Fields{"err": err}).Error("Error shutting down neo4j; backup process failed.")
@@ -193,7 +194,7 @@ func runInner(
 		log.WithFields(log.Fields{"err": err}).Error("Error creating backup tarball.")
 		return err
 	}
-	log.WithFields(log.Fields{"archiveName": archiveName, "err": err}).Info("Archive created, uploading archive to S3.")
+	log.WithFields(log.Fields{"archiveName": archiveName, "err": err}).Info("Initial tar/gzip archive created, streaming data to S3 as it is added to the archive...")
 	err = uploadToS3(bucketWriter, pipeReader)
 	if err != nil {
 		log.WithFields(log.Fields{"archiveName": archiveName, "err": err}).Error("Error uploading to S3; backup process failed.")


### PR DESCRIPTION
… because the hot rsync process is prone to failure in busy environments.

Currently, the neo4j backup service exits after two non-zero return codes from rsync during the "hot backup" phase (i.e. while neo is running). This PR changes the behaviour so that it doesn't exit. The consequence of this new behaviour is that the cold backup phase (i.e. while neo is shut down) takes longer to copy files. However, the 'blue' instance of neo4j will always be running, so availability of services that dependent on neo shouldn't be affected.

Sample logs from a failed process:

```
Jun 15 12:56:56 ip-172-24-151-154.eu-west-1.compute.internal sh[7898]: time="2016-06-15T12:56:56Z" level=error msg="Error executing rsync command!" err="exit status 24" output="sending incremental file list\nmessages.log\nneostore\nneostore.counts.db.b\nneostore.nodestore.db\nneostore.propertystore.db\nneostore.propertystore.db.strings\nneostore.relationshipgroupstore.db\nneostore.relationshipstore.db\nneostore.transaction.db.336\nschema/index/lucene/1/\nfile has vanished: \"/data/graph.db/schema/index/lucene/1/_hb10.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/1/_hb3w.cfs\"\nschema/index/lucene/1/segments.gen\nfile has vanished: \"/data/graph.db/schema/index/lucene/1/segments_7nr\"\nschema/index/lucene/13/\nfile has vanished: \"/data/graph.db/schema/index/lucene/13/_4b0x.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/13/_4b3z.cfs\"\nschema/index/lucene/13/segments.gen\nfile has vanished: \"/data/graph.db/schema/index/lucene/13/segments_746\"\nschema/index/lucene/17/\nschema/index/lucene/17/_3dzl.cfs\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3ee9.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3eea.cfs\"\nschema/index/lucene/17/_3its.cfs\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3k28.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3ky9.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3kya.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3kyb.fdt\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3kyb.fdx\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3kyb.fnm\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3kyb.frq\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3kyb.tii\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3kyb.tis\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/_3kyc.cfs\"\nschema/index/lucene/17/segments.gen\nfile has vanished: \"/data/graph.db/schema/index/lucene/17/segments_9\"\nschema/index/lucene/35/\nfile has vanished: \"/data/graph.db
Jun 15 12:56:56 ip-172-24-151-154.eu-west-1.compute.internal sh[7898]: /schema/index/lucene/35/_3eak.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3eii.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3eij.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3eil.cfs\"\nschema/index/lucene/35/_3l1e.cfs\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3l3a.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3l3b.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3l3d.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3l3d.fdt\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3l3d.fdx\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3l3d.fnm\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3l3d.frq\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3l3d.nrm\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3l3d.tii\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/_3l3d.tis\"\nschema/index/lucene/35/segments.gen\nfile has vanished: \"/data/graph.db/schema/index/lucene/35/segments_b\"\nschema/index/lucene/37/\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3do3.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3e58.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3e59.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3e5b.cfs\"\nschema/index/lucene/37/_3fc2.cfs\nschema/index/lucene/37/_3ik7.cfs\nschema/index/lucene/37/_3k71.cfs\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3kpk.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3kpl.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3kpm.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3kpm.fdt\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3kpm.fdx\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3kpm.fnm\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3kpm.frq\"\nfile has van
Jun 15 12:56:56 ip-172-24-151-154.eu-west-1.compute.internal sh[7898]: ished: \"/data/graph.db/schema/index/lucene/37/_3kpm.tii\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/_3kpm.tis\"\nschema/index/lucene/37/segments.gen\nfile has vanished: \"/data/graph.db/schema/index/lucene/37/segments_9\"\nschema/label/lucene/\nschema/label/lucene/_n06v_1.del\nschema/label/lucene/_nl0n_1.del\nfile has vanished: \"/data/graph.db/schema/label/lucene/_nvec.cfs\"\nfile has vanished: \"/data/graph.db/schema/label/lucene/_o220.cfs\"\nschema/label/lucene/segments.gen\nfile has vanished: \"/data/graph.db/schema/label/lucene/segments_7r1\"\n\nsent 6,685,720,621 bytes  received 1,481 bytes  22,028,738.39 bytes/sec\ntotal size is 11,409,264,866  speedup is 1.71\nrsync warning: some files vanished before they could be transferred (code 24) at main.c(1178) [sender=3.1.2]\n" sourceDir="/data/graph.db/" targetDir="/data/graph.db.backup"
Jun 15 12:56:56 ip-172-24-151-154.eu-west-1.compute.internal sh[7898]: time="2016-06-15T12:56:56Z" level=warning msg="Encountered another error synchronising neo4j files while database is running (i.e. hot); backup process failed." dataFolder="/data/graph.db/" err="exit status 24" targetFolder="/data/graph.db.backup"
Jun 15 12:56:57 ip-172-24-151-154.eu-west-1.compute.internal systemd[1]: neo4j-backup.service: Main process exited, code=exited, status=1/FAILURE
Jun 15 12:56:57 ip-172-24-151-154.eu-west-1.compute.internal systemd[1]: Failed to start Job to backup neo4j DB data files to S3.
Jun 15 12:56:57 ip-172-24-151-154.eu-west-1.compute.internal systemd[1]: neo4j-backup.service: Unit entered failed state.
Jun 15 12:56:57 ip-172-24-151-154.eu-west-1.compute.internal systemd[1]: neo4j-backup.service: Failed with result 'exit-code'.
Jun 15 13:08:28 ip-172-24-151-154.eu-west-1.compute.internal systemd[1]: Stopped Job to backup neo4j DB data files to S3.
Jun 15 13:08:33 ip-172-24-151-154.eu-west-1.compute.internal systemd[1]: Starting Job to backup neo4j DB data files to S3...
Jun 15 13:08:33 ip-172-24-151-154.eu-west-1.compute.internal docker[15566]: Failed to kill container (neo4j-backup): Error response from daemon: Cannot kill container neo4j-backup: No such container: neo4j-backup
Jun 15 13:08:33 ip-172-24-151-154.eu-west-1.compute.internal docker[15576]: Failed to remove container (neo4j-backup): Error response from daemon: No such container: neo4j-backup
Jun 15 13:08:34 ip-172-24-151-154.eu-west-1.compute.internal sh[15590]: time="2016-06-15T13:08:34Z" level=info msg="Starting backup operation at startTime={63601592914 355096320 14868864}."
Jun 15 13:08:34 ip-172-24-151-154.eu-west-1.compute.internal sh[15590]: time="2016-06-15T13:08:34Z" level=info msg="Connecting to fleet API." url=http://localhost:49153
Jun 15 13:08:34 ip-172-24-151-154.eu-west-1.compute.internal sh[15590]: time="2016-06-15T13:08:34Z" level=info msg="Connection successfully established to fleet API." url=http://localhost:49153
Jun 15 13:08:34 ip-172-24-151-154.eu-west-1.compute.internal sh[15590]: time="2016-06-15T13:08:34Z" level=info msg="Starting first hot rsync process." dataFolder="/data/graph.db/" targetFolder="/data/graph.db.backup"
Jun 15 13:13:16 ip-172-24-151-154.eu-west-1.compute.internal sh[15590]: time="2016-06-15T13:13:16Z" level=error msg="Error executing rsync command!" err="exit status 24" output="sending incremental file list\nmessages.log\nneostore\nneostore.counts.db.a\nneostore.counts.db.b\nneostore.nodestore.db\nneostore.propertystore.db\nneostore.propertystore.db.strings\nneostore.relationshipgroupstore.db\nneostore.relationshipstore.db\nneostore.relationshipstore.db.id\nneostore.transaction.db.336\ndeleting schema/index/lucene/17/_3its.cfs\ndeleting schema/index/lucene/17/_3dzl.cfs\ndeleting schema/index/lucene/17/_2tcm.cfs\ndeleting schema/index/lucene/17/_1ocn.cfs\ndeleting schema/index/lucene/35/_7wx.cfs\ndeleting schema/index/lucene/35/_3l1e.cfs\ndeleting schema/index/lucene/35/_3dch.cfs\ndeleting schema/index/lucene/35/_2x3i.cfs\ndeleting schema/index/lucene/35/_20mx.cfs\ndeleting schema/index/lucene/37/_3k71.cfs\ndeleting schema/index/lucene/37/_3ik7.cfs\ndeleting schema/index/lucene/37/_3fc2.cfs\ndeleting schema/index/lucene/37/_3bzt.cfs\ndeleting schema/index/lucene/37/_38hi.cfs\ndeleting schema/label/lucene/_nl0n_1.del\ndeleting schema/label/lucene/_nl0n.cfs\ndeleting schema/label/lucene/_n06v_1.del\ndeleting schema/label/lucene/_n06v.cfs\ndeleting schema/label/lucene/_luet_1.del\ndeleting schema/label/lucene/_luet.cfs\nschema/index/lucene/1/\nschema/index/lucene/1/_hbau.cfs\nfile has vanished: \"/data/graph.db/schema/index/lucene/1/_hbd3.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/1/_hbdt.cfs\"\nschema/index/lucene/1/segments.gen\nfile has vanished: \"/data/graph.db/schema/index/lucene/1/segments_7nv\"\nschema/index/lucene/13/\nschema/index/lucene/13/_4b8b.cfs\nfile has vanished: \"/data/graph.db/schema/index/lucene/13/_4bcq.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/13/_4bdq.cfs\"\nschema/index/lucene/13/segments.gen\nfile has vanished: \"/data/graph.db/schema/index/lucene/13/segments_74a\"\nschema/index/lucene/17/\nschema/index/lucene/17/_3xwv.cfs\nschema/index/lucene/17/_3z0n.cfs\nschema/index/lucene/17/segments.gen\nschema/index/lucene/17/segm
Jun 15 13:13:16 ip-172-24-151-154.eu-west-1.compute.internal sh[15590]: ents_c\nschema/index/lucene/35/\nschema/index/lucene/35/_3t5n.cfs\nschema/index/lucene/35/_3wyv.cfs\nschema/index/lucene/35/_3yz2.cfs\nschema/index/lucene/35/_3z5y.cfs\nschema/index/lucene/35/segments.gen\nschema/index/lucene/35/segments_e\nschema/index/lucene/37/\nschema/index/lucene/37/_3skq.cfs\nschema/index/lucene/37/_3vy4.cfs\nschema/index/lucene/37/_3xnd.cfs\nschema/index/lucene/37/_3yil.cfs\nschema/index/lucene/37/_3yrj.cfs\nschema/index/lucene/37/segments.gen\nschema/index/lucene/37/segments_c\nschema/label/lucene/\nschema/label/lucene/_o57l.cfs\nschema/label/lucene/_o57l_1.del\nfile has vanished: \"/data/graph.db/schema/label/lucene/_oghs.cfs\"\nfile has vanished: \"/data/graph.db/schema/label/lucene/_ogj8.cfs\"\nschema/label/lucene/segments.gen\nfile has vanished: \"/data/graph.db/schema/label/lucene/segments_7r5\"\n\nsent 6,783,373,287 bytes  received 1,630 bytes  24,097,246.60 bytes/sec\ntotal size is 11,446,556,840  speedup is 1.69\nrsync warning: some files vanished before they could be transferred (code 24) at main.c(1178) [sender=3.1.2]\n" sourceDir="/data/graph.db/" targetDir="/data/graph.db.backup"
Jun 15 13:13:16 ip-172-24-151-154.eu-west-1.compute.internal sh[15590]: time="2016-06-15T13:13:16Z" level=warning msg="Error synchronising neo4j files while database is running (i.e. hot); re-trying once." dataFolder="/data/graph.db/" err="exit status 24" targetFolder="/data/graph.db.backup"
Jun 15 13:18:01 ip-172-24-151-154.eu-west-1.compute.internal sh[15590]: time="2016-06-15T13:18:01Z" level=error msg="Error executing rsync command!" err="exit status 24" output="sending incremental file list\nmessages.log\nneostore\nneostore.counts.db.a\nneostore.nodestore.db\nneostore.propertystore.db\nneostore.propertystore.db.strings\nneostore.relationshipgroupstore.db\nneostore.relationshipstore.db\nneostore.transaction.db.336\nschema/index/lucene/1/\nfile has vanished: \"/data/graph.db/schema/index/lucene/1/_hbfx.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/1/_hbgl.cfs\"\nschema/index/lucene/1/segments.gen\nfile has vanished: \"/data/graph.db/schema/index/lucene/1/segments_7nw\"\nschema/index/lucene/13/\nfile has vanished: \"/data/graph.db/schema/index/lucene/13/_4bfu.cfs\"\nfile has vanished: \"/data/graph.db/schema/index/lucene/13/_4bgi.cfs\"\nschema/index/lucene/13/segments.gen\nfile has vanished: \"/data/graph.db/schema/index/lucene/13/segments_74b\"\nschema/label/lucene/\nfile has vanished: \"/data/graph.db/schema/label/lucene/_ogmm.cfs\"\nfile has vanished: \"/data/graph.db/schema/label/lucene/_ogna.cfs\"\nschema/label/lucene/segments.gen\nfile has vanished: \"/data/graph.db/schema/label/lucene/segments_7r6\"\n\nsent 6,704,322,026 bytes  received 453 bytes  23,482,740.73 bytes/sec\ntotal size is 11,446,985,836  speedup is 1.71\nrsync warning: some files vanished before they could be transferred (code 24) at main.c(1178) [sender=3.1.2]\n" sourceDir="/data/graph.db/" targetDir="/data/graph.db.backup"
Jun 15 13:18:01 ip-172-24-151-154.eu-west-1.compute.internal sh[15590]: time="2016-06-15T13:18:01Z" level=warning msg="Encountered another error synchronising neo4j files while database is running (i.e. hot); backup process failed." dataFolder="/data/graph.db/" err="exit status 24" targetFolder="/data/graph.db.backup"
Jun 15 13:18:01 ip-172-24-151-154.eu-west-1.compute.internal systemd[1]: neo4j-backup.service: Main process exited, code=exited, status=1/FAILURE
Jun 15 13:18:01 ip-172-24-151-154.eu-west-1.compute.internal systemd[1]: Failed to start Job to backup neo4j DB data files to S3.
Jun 15 13:18:01 ip-172-24-151-154.eu-west-1.compute.internal systemd[1]: neo4j-backup.service: Unit entered failed state.
Jun 15 13:18:01 ip-172-24-151-154.eu-west-1.compute.internal systemd[1]: neo4j-backup.service: Failed with result 'exit-code'.
```
